### PR TITLE
Adding OCI_VERSION

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,5 +22,6 @@ ENV LD_LIBRARY_PATH="/opt/oracle/instantclient”
 ENV OCI_HOME="/opt/oracle/instantclient”
 ENV OCI_LIB_DIR="/opt/oracle/instantclient”
 ENV OCI_INCLUDE_DIR="/opt/oracle/instantclient/sdk/include"
+ENV OCI_VERSION=12
 
 RUN echo '/opt/oracle/instantclient/' | tee -a /etc/ld.so.conf.d/oracle_instant_client.conf && ldconfig


### PR DESCRIPTION
By default the OCI_VERSION defaults to 11. Setting it to 12 explicitly, since we are using Oracle Instant Client Version 12.1
