### PR TITLE
Update Dockerfile for node-oracledb v2 compatibility on linux

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,5 +23,6 @@ ENV OCI_HOME="/opt/oracle/instantclient"
 ENV OCI_LIB_DIR="/opt/oracle/instantclient"
 ENV OCI_INCLUDE_DIR="/opt/oracle/instantclient/sdk/include"
 ENV OCI_VERSION=12
+ENV LD_LIBRARY_PATH /opt/oracle/instantclient
 
 RUN echo '/opt/oracle/instantclient/' | tee -a /etc/ld.so.conf.d/oracle_instant_client.conf && ldconfig


### PR DESCRIPTION
add environment variable for linux compatibility with node-oracledb v2

addresses https://github.com/CollinEstes/docker-node-oracle/issues/17

existing environment variables remain the same for compatibility with node-oracledb v1